### PR TITLE
[codex] Add tracker-level template rendering

### DIFF
--- a/dist/frontend.js
+++ b/dist/frontend.js
@@ -18067,10 +18067,15 @@ function compileTemplate(preset) {
 }
 function buildTemplateData(data, preset, previousData) {
   const worldData = data.worldData || {};
-  const characters = normalizeCharacters(data);
+  const configuredMaxCharacters = Number(preset.extSettings?.maxCharacters);
+  const maxCharacters = Number.isFinite(configuredMaxCharacters) && configuredMaxCharacters > 0 ? Math.floor(configuredMaxCharacters) : Number.POSITIVE_INFINITY;
+  const characters = normalizeCharacters(data).slice(0, maxCharacters);
   const currentDate = typeof worldData.current_date === "string" ? worldData.current_date : "Unknown Date";
   const currentTime = typeof worldData.current_time === "string" ? worldData.current_time : "Unknown Time";
   const tabbed = (preset.htmlTemplate || "").includes("sim-tracker-tabs") || preset.id.includes("tabs");
+  // Positioned templates normally compile once per character. Tracker mode is
+  // an explicit opt-in for layouts that need one world panel around all cards.
+  const trackerLevel = preset.extSettings?.renderMode === "tracker";
   const statChanges = calculateStatChanges(characters, previousData);
   const characterPayload = characters.map((character) => {
     const stats = character;
@@ -18108,11 +18113,12 @@ function buildTemplateData(data, preset, previousData) {
       showThoughtBubble: true
     };
   });
-  if (tabbed) {
+  if (tabbed || trackerLevel) {
     return {
-      tabbed: true,
+      renderMode: trackerLevel ? "tracker" : "tabbed",
       input: {
         characters: characterPayload,
+        worldData,
         currentDate,
         currentTime
       },
@@ -18120,9 +18126,10 @@ function buildTemplateData(data, preset, previousData) {
     };
   }
   return {
-    tabbed: false,
+    renderMode: "single",
     input: {
       characters: characterPayload,
+      worldData,
       currentDate,
       currentTime
     },
@@ -18159,8 +18166,8 @@ function buildTrackerMarkup(data, preset, previousData) {
   const prep = buildTemplateData(data, preset, previousData);
   try {
     let cardsHtml = "";
-    if (prep.tabbed) {
-      const transformed = executeTemplateLogic(prep.input, "tabbed", preset);
+    if (prep.renderMode !== "single") {
+      const transformed = executeTemplateLogic(prep.input, prep.renderMode, preset);
       cardsHtml = compiled(transformed);
     } else {
       const inputChars = prep.input.characters || [];

--- a/docs/template-guide-positioned-cards.md
+++ b/docs/template-guide-positioned-cards.md
@@ -351,6 +351,51 @@ List all available variables here
 - `"BOTTOM"` - Cards appear below chat messages
 - `"LEFT"` / `"RIGHT"` - Sidebar positions (see other guides)
 
+### Tracker-Level Positioned Templates
+
+Positioned templates compile once per character by default. Use tracker-level
+rendering when a template needs one shared world/story panel plus a collection
+of character cards:
+
+```json
+"extSettings": {
+  "codeBlockIdentifier": "sim",
+  "renderMode": "tracker",
+  "maxCharacters": 4
+}
+```
+
+With `renderMode: "tracker"`, the template is compiled once and receives:
+
+- `{{worldData}}` - the complete top-level world object.
+- `{{characters}}` - normalized character template records.
+- `{{currentDate}}` and `{{currentTime}}` - convenience values derived from
+  `worldData.current_date` and `worldData.current_time`.
+
+Iterate over character records inside the template:
+
+```handlebars
+<section class="world-panel">
+  <h2>{{worldData.part_of_day}}</h2>
+  <p>{{worldData.immediate_narrative_thread}}</p>
+</section>
+
+<div class="character-grid">
+  {{#each characters}}
+    <article style="--accent: {{bgColor}};">
+      <h2>{{characterName}}</h2>
+      <p>{{stats.internal_thought}}</p>
+    </article>
+  {{else}}
+    <p>No characters are currently tracked.</p>
+  {{/each}}
+</div>
+```
+
+`maxCharacters` is optional. When present, it limits the normalized character
+array before change calculation and rendering. Existing templates that omit
+`renderMode` continue using per-character compilation without behavior changes.
+
 ---
 
 ## 5. System Prompt Creation

--- a/src/frontend.ts
+++ b/src/frontend.ts
@@ -880,7 +880,11 @@ function extractTemplateLogic(htmlTemplate?: string): string | null {
   return match[1].trim();
 }
 
-function executeTemplateLogic<T extends Record<string, unknown>>(input: T, templateType: "single" | "tabbed", preset: TemplatePreset): T {
+function executeTemplateLogic<T extends Record<string, unknown>>(
+  input: T,
+  templateType: "single" | "tabbed" | "tracker",
+  preset: TemplatePreset,
+): T {
   const logic = extractTemplateLogic(preset.htmlTemplate);
   if (!logic) return input;
   try {
@@ -1087,12 +1091,23 @@ function buildTemplateData(
   data: TrackerData,
   preset: TemplatePreset,
   previousData: TrackerData | null,
-): { tabbed: boolean; input: Record<string, unknown>; fallbackRaw: string } {
+): {
+  renderMode: "single" | "tabbed" | "tracker";
+  input: Record<string, unknown>;
+  fallbackRaw: string;
+} {
   const worldData = (data.worldData || {}) as Record<string, unknown>;
-  const characters = normalizeCharacters(data);
+  const configuredMaxCharacters = Number(preset.extSettings?.maxCharacters);
+  const maxCharacters = Number.isFinite(configuredMaxCharacters) && configuredMaxCharacters > 0
+    ? Math.floor(configuredMaxCharacters)
+    : Number.POSITIVE_INFINITY;
+  const characters = normalizeCharacters(data).slice(0, maxCharacters);
   const currentDate = typeof worldData.current_date === "string" ? worldData.current_date : "Unknown Date";
   const currentTime = typeof worldData.current_time === "string" ? worldData.current_time : "Unknown Time";
   const tabbed = (preset.htmlTemplate || "").includes("sim-tracker-tabs") || preset.id.includes("tabs");
+  // Positioned templates normally compile once per character. Tracker mode is
+  // an explicit opt-in for layouts that need one world panel around all cards.
+  const trackerLevel = preset.extSettings?.renderMode === "tracker";
   const statChanges = calculateStatChanges(characters, previousData);
 
   const characterPayload = characters.map((character) => {
@@ -1143,11 +1158,12 @@ function buildTemplateData(
     };
   });
 
-  if (tabbed) {
+  if (tabbed || trackerLevel) {
     return {
-      tabbed: true,
+      renderMode: trackerLevel ? "tracker" : "tabbed",
       input: {
         characters: characterPayload,
+        worldData,
         currentDate,
         currentTime,
       },
@@ -1156,9 +1172,10 @@ function buildTemplateData(
   }
 
   return {
-    tabbed: false,
+    renderMode: "single",
     input: {
       characters: characterPayload,
+      worldData,
       currentDate,
       currentTime,
     },
@@ -1207,8 +1224,8 @@ function buildTrackerMarkup(
   const prep = buildTemplateData(data, preset, previousData);
   try {
     let cardsHtml = "";
-    if (prep.tabbed) {
-      const transformed = executeTemplateLogic(prep.input, "tabbed", preset);
+    if (prep.renderMode !== "single") {
+      const transformed = executeTemplateLogic(prep.input, prep.renderMode, preset);
       cardsHtml = compiled(transformed);
     } else {
       const inputChars = ((prep.input.characters as Array<Record<string, unknown>>) || []);

--- a/src/templatePresets.ts
+++ b/src/templatePresets.ts
@@ -22,6 +22,10 @@ export type TemplatePreset = {
   customFields?: TemplateField[];
   extSettings?: {
     codeBlockIdentifier?: string;
+    /** Compile once with `worldData` and the normalized `characters` array. */
+    renderMode?: string;
+    /** Optional display cap applied after character normalization. */
+    maxCharacters?: number;
     [key: string]: unknown;
   };
 };


### PR DESCRIPTION
## Summary

- add an opt-in `extSettings.renderMode: "tracker"` mode that compiles a positioned template once with the complete normalized character collection
- expose top-level `worldData`, `currentDate`, and `currentTime` to tracker-level templates
- add an optional `extSettings.maxCharacters` cap applied after normalization and before change calculation/rendering
- document the new authoring contract and include the corresponding frontend bundle update

## Why

Positioned templates currently compile once per character. That works for independent cards, but it prevents a template from rendering one shared world/story panel alongside several character cards. The new mode is explicitly opt-in, so existing per-character and tabbed templates retain their current behavior.

No tracker parser behavior or canonical data normalization changes are included.

## Example preset

The preset that motivated this capability intentionally lives only in the fork and is **not included in this PR**:

- [Narrative Weave HTML template](https://github.com/ajrc0re/Lumiverse-SimTracker/blob/main/custom/narrative-weave-simtracker.html)
- [Narrative Weave importable preset JSON](https://github.com/ajrc0re/Lumiverse-SimTracker/blob/main/custom/narrative-weave-simtracker.json)

## Validation

- `bun run typecheck`
- `bun run build`
- `node --check dist/frontend.js`
- precompiled all 13 existing bundled Handlebars templates
- verified the upstream comparison contains only the renderer, option typings, authoring guide, and frontend bundle
